### PR TITLE
Register geoip2/geoip2 composer dependency as Magento lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "keywords": ["magento2", "MaxMind"],
   "license":["MIT"],
   "type": "magento2-module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repositories": [
     {
       "type": "composer",

--- a/registration.php
+++ b/registration.php
@@ -8,3 +8,10 @@
     'Tobai_GeoIp2',
     __DIR__
 );
+
+// Register geoip2/geoip2 compoer dependency as Magento lib
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::LIBRARY,
+    'Tobai_GeoIp2_Lib',
+    __DIR__ . '\..\..\geoip2\geoip2'
+);


### PR DESCRIPTION
When Magento is compiled, ```ReaderFactory``` will fail to resolve parameters of ```GeoIp2\Database\Reader``` that is created through ```ObjectManager```.

It is required to register composer dependency ```geoip2/geoip2``` as Magento library in order for _Area configuration aggregation_ process to sucesfully scan the lib and allow ```ObjectManager``` to work with it, even when compiled.